### PR TITLE
New features: Pass changed file info and allow invoking other plugins' hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ custom:
     - path:
         - src/api
         - src/cow/*.js
-      command: echo "api folder or js file in cow folder was modified!"
+      command:
+        - echo "api folder or js file in cow folder was modified!"
+        - echo "the command-option can also be an array of commands"
     - path:
         - src/**/**
       # this prints for example "received change event for src/path/to/file.ts"
@@ -63,13 +65,13 @@ export default {
 ```
 
 In addition to running arbitrary shell commands, the plugin can also invoke a hook in some other
-serverless plugin, with the `hooks` option. The following will ask `serverless-offline` to
+serverless plugin, with the `hook` option. The following will ask `serverless-offline` to
 clear its Worker cache when a file in the `src` directory is changed:
 
 ```yaml
     - path:
         - src/**/*
-      hooks:
+      hook:
         - offline:functionsUpdated
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ export default {
 }
 ```
 
+In addition to running arbitrary shell commands, the plugin can also invoke a hook in some other
+serverless plugin, with the `hooks` option. The following will ask `serverless-offline` to
+clear its Worker cache when a file in the `src` directory is changed:
+
+```yaml
+    - path:
+        - src/**/*
+      hooks:
+        - offline:functionsUpdated
+```
+
 ### Running serverless-offline
 
 Use `serverless offline start` instead of `serverless offline`, if you aren't already. This is necessary for serverless-offline to fire off `init` and `end` lifecycle hooks so that we can start and stop the watch server correctly.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ custom:
       command: echo "api folder or js file in cow folder was modified!"
     - path:
         - src/**/**
+      # this prints for example "received change event for src/path/to/file.ts"
       command: "echo received $WATCHER_EVENT_TYPE event for $WATCHER_EVENT_PATH"
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Add it to your list of plugins, and custom config for what you want to do on fil
 
 The `path` property may be a string, or array of strings. They be file paths, directory paths or glob patterns. Under the hood this library uses [chokidar](https://github.com/paulmillr/chokidar) for file watching and [picomatch](https://github.com/micromatch/picomatch) for glob patterns, so you can see there documentation for more details about supported patterns.
 
+The event type and the changed file path are available in environment variables `WATCHER_EVENT_TYPE` and `WATCHER_EVENT_PATH` respectively. The event type comes from chokidar and is one of `"add" | "addDir" | "change" | "unlink" | "unlinkDir"`.
+
 serverless.yaml:
 
 ```yaml
@@ -31,6 +33,9 @@ custom:
         - src/api
         - src/cow/*.js
       command: echo "api folder or js file in cow folder was modified!"
+    - path:
+        - src/**/**
+      command: "echo received $WATCHER_EVENT_TYPE event for $WATCHER_EVENT_PATH"
 ```
 
 serverless.js / serverless.ts:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,7 +49,7 @@ test('serverless-offline-watcher', async () => {
 
   // then... we have a mock watcher created
   expect(mockMakeWatcher).toHaveBeenCalledTimes(1);
-  expect(mockMakeWatcher).toHaveBeenCalledWith(serverlessMock.service.custom['serverless-offline-watcher'], expect.any(Object));
+  expect(mockMakeWatcher).toHaveBeenCalledWith(serverlessMock.service.custom['serverless-offline-watcher'], serverlessMock);
 
   // then... we provide init and end hooks
   expect(plugin.hooks).toHaveProperty('before:offline:start:init', expect.any(Function));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,10 +11,21 @@ test('serverless-offline-watcher', async () => {
   const serverlessMock = {
     service: {
       custom: {
-        'serverless-offline-watcher': [{
-          path: 'some/path',
-          command: 'echo "hi"',
-        }],
+        'serverless-offline-watcher': [
+          {
+            path: 'some/path',
+            command: 'echo "hi"',
+          },
+          {
+            path: 'other/path',
+            command: [
+              'echo "hi"',
+            ],
+            hook: [
+              'test',
+            ],
+          },
+        ],
         'some-other-plugin-that-should-not-interfere': {
           port: 2222,
         },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,7 +38,7 @@ test('serverless-offline-watcher', async () => {
 
   // then... we have a mock watcher created
   expect(mockMakeWatcher).toHaveBeenCalledTimes(1);
-  expect(mockMakeWatcher).toHaveBeenCalledWith(serverlessMock.service.custom['serverless-offline-watcher']);
+  expect(mockMakeWatcher).toHaveBeenCalledWith(serverlessMock.service.custom['serverless-offline-watcher'], expect.any(Object));
 
   // then... we provide init and end hooks
   expect(plugin.hooks).toHaveProperty('before:offline:start:init', expect.any(Function));

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ class ServerlessOfflineWatcherPlugin implements Plugin {
       if (typeof v.path !== 'string') throw new Error(`${PLUGIN_NAME}: config entry path property must be a string or string array, but the entry at index ${i} has a path with type ${typeof v.path}`);
     });
 
-    this.watcher = makeWatcher(this.config);
+    this.watcher = makeWatcher(this.config, serverless);
 
     if (this.config.length === 0) {
       this.serverless.cli.log(`${PLUGIN_NAME}: no entries in configuration, not doing anything`);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -20,8 +20,13 @@ export const makeWatcher = (config: Config): Watcher => {
       config.forEach((c) => {
         const internalWatcher = chokidar.watch(c.path, { ignoreInitial: true });
 
-        internalWatcher.on('all', () => {
-          const call = exec(c.command, () => {
+        internalWatcher.on('all', (eventType, eventPath) => {
+          const env = {
+            ...process.env,
+            WATCHER_EVENT_TYPE: eventType,
+            WATCHER_EVENT_PATH: eventPath,
+          };
+          const call = exec(c.command, { env }, () => {
             if (call.pid) {
               delete processes[call.pid];
             }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,44 +1,61 @@
 import chokidar from 'chokidar';
 import { exec, ChildProcess } from 'child_process';
+import type Serverless from 'serverless';
 
-export type Config = {
+type ConfigItem = {
   path: string | string[];
-  command: string;
-}[];
+  command?: string;
+  hooks?: string | string[];
+};
+
+export type Config = ConfigItem[];
 
 export interface Watcher {
   start: () => void;
   stop: () => Promise<void>;
 }
 
-export const makeWatcher = (config: Config): Watcher => {
+export const makeWatcher = (config: Config, serverless: Serverless): Watcher => {
   const internalWatchers: chokidar.FSWatcher[] = [];
   const processes: { [pid: number]: ChildProcess } = {};
+
+  const runCommand = (command: string, eventType: string, eventPath: string) => new Promise<void>((resolve) => {
+    const env = {
+      ...process.env,
+      WATCHER_EVENT_TYPE: eventType,
+      WATCHER_EVENT_PATH: eventPath,
+    };
+    const call = exec(command, { env }, () => {
+      if (call.pid) {
+        delete processes[call.pid];
+      }
+    });
+    call.stdout?.pipe(process.stdout);
+    call.stderr?.pipe(process.stderr);
+    if (!call.pid) {
+      // Failed to start, make sure it's killed
+      call.kill();
+    } else {
+      processes[call.pid] = call;
+    }
+    call.on('close', () => resolve());
+  });
+
+  const runHook = (hookName: string) => {
+    serverless.pluginManager.spawn(hookName);
+  };
 
   return {
     start: () => {
       config.forEach((c) => {
         const internalWatcher = chokidar.watch(c.path, { ignoreInitial: true });
 
-        internalWatcher.on('all', (eventType, eventPath) => {
-          const env = {
-            ...process.env,
-            WATCHER_EVENT_TYPE: eventType,
-            WATCHER_EVENT_PATH: eventPath,
-          };
-          const call = exec(c.command, { env }, () => {
-            if (call.pid) {
-              delete processes[call.pid];
-            }
-          });
-          call.stdout?.pipe(process.stdout);
-          call.stderr?.pipe(process.stderr);
-          if (!call.pid) {
-            // Failed to start, make sure it's killed
-            call.kill();
-          } else {
-            processes[call.pid] = call;
+        internalWatcher.on('all', async (eventType, eventPath) => {
+          if (c.command) {
+            await runCommand(c.command, eventType, eventPath);
           }
+          const hooks: string[] = ([] as string[]).concat(c.hooks || []);
+          hooks.forEach(runHook);
         });
 
         internalWatchers.push(internalWatcher);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -4,8 +4,8 @@ import type Serverless from 'serverless';
 
 type ConfigItem = {
   path: string | string[];
-  command?: string;
-  hooks?: string | string[];
+  command?: string | string[];
+  hook?: string | string[];
 };
 
 export type Config = ConfigItem[];
@@ -51,11 +51,12 @@ export const makeWatcher = (config: Config, serverless: Serverless): Watcher => 
         const internalWatcher = chokidar.watch(c.path, { ignoreInitial: true });
 
         internalWatcher.on('all', async (eventType, eventPath) => {
-          if (c.command) {
-            await runCommand(c.command, eventType, eventPath);
+          // eslint-disable-next-line no-restricted-syntax
+          for (const command of normalizeStringArray(c.command)) {
+            // eslint-disable-next-line no-await-in-loop
+            await runCommand(command, eventType, eventPath);
           }
-          const hooks: string[] = ([] as string[]).concat(c.hooks || []);
-          hooks.forEach(runHook);
+          normalizeStringArray(c.hook).forEach(runHook);
         });
 
         internalWatchers.push(internalWatcher);
@@ -70,3 +71,5 @@ export const makeWatcher = (config: Config, serverless: Serverless): Watcher => 
     },
   };
 };
+
+const normalizeStringArray = (valueOrValues: void | string | string[]): string[] => ([] as string[]).concat(valueOrValues || []);


### PR DESCRIPTION
Closes #6  
Closes #7  

This PR implements the two features that I requested in the linked issues: It exposes the changed file name in an environment variable `WATCHER_EVENT_PATH`, and additionally also the event type ("add", "change", etc.) via `WATCHER_EVENT_TYPE`.

This PR also adds a new configuration option, `hooks`, to be optionally used with or without the already existing `command` option. When specified, file changes will cause the specified hooks of other plugins to be invoked.

I combined the two feature implementations' commits in one PR because they touch largely the same files so I figured it'd be less of a burden to eventually merge them to master without conflicts, if you so choose.  However, if you want to accept only one of the features and not the other, then I can make a new PR with just that patch too.

 